### PR TITLE
Check metadata for each view individually

### DIFF
--- a/mofax/utils.py
+++ b/mofax/utils.py
@@ -73,18 +73,18 @@ def _load_features_metadata(model):
         columns=["feature", "view"],
     )
     if "features_metadata" in model.model:
-        if len(list(model.model["features_metadata"][model.views[0]].keys())) > 0:
-            features_metadata_dict = {
-                m: pd.concat(
+        features_metadata_dict = {}
+        for m in model.views:
+            if len(list(model.model["features_metadata"][m].keys())) > 0:
+                features_metadata_dict[m] = pd.concat(
                     [
                         pd.Series(model.model["features_metadata"][m][k])
                         for k in model.model["features_metadata"][m].keys()
                     ],
                     axis=1,
                 )
-                for m in model.views
-            }
-
+                
+        if len(features_metadata_dict) > 0:
             for m in features_metadata_dict.keys():
                 features_metadata_dict[m].columns = list(
                     model.model["features_metadata"][m].keys()


### PR DESCRIPTION
This PR makes sure that the metadata is checked for each view individually. If this is not the case, then a view without metadata is assumed to have metadat as long as the first view has some. Assuming non-existing metadata leads to a concatenation of empty series, which breaks the code.

Here is a small example to reproduce the bug: Computing HVG on the mrna view leads to the issue, because this operation creates the metadata for the mrna view.

```python
import scanpy as sc
import muon as mu
import pandas as pd
import mofax as mfx

drugs = pd.read_csv("data/cll_drugs.csv", index_col=0).T
metadata = pd.read_csv("data/cll_metadata.csv", index_col=0).T
mrna = pd.read_csv("data/cll_mrna.csv", index_col=0).T

mrna = sc.AnnData(mrna)
drugs = sc.AnnData(drugs)

sc.pp.highly_variable_genes(mrna, n_top_genes=10)
mrna = mrna[:, mrna.var["highly_variable"]]

mods = {"mrna": mrna, "drugs": drugs}

obs = pd.read_csv("data/cll_metadata.csv", sep=",", index_col=0)

mdata = mu.MuData(mods)
mdata.obs = mdata.obs.join(obs)

mu.tl.mofa(
    mdata,
    use_obs="union",
    n_factors=3,
    convergence_mode="medium",
    outfile="models/temp.hdf5",
    save_metadata=True,
    save_data=True,
    verbose=False,
)

model = mfx.mofa_model("models/temp.hdf5")
```
 