### PR TITLE
Update plot_variance.py

### DIFF
--- a/mofax/plot_variance.py
+++ b/mofax/plot_variance.py
@@ -69,6 +69,7 @@ def plot_r2(
         views=views,
         group_label=group_label,
         groups_df=groups_df,
+        per_factor=True
     )
 
     vmax = r2.R2.max() if vmax is None else vmax


### PR DESCRIPTION
Added per_factor=True to the get_r2 call on the plot_r2 function, allowing to use a group_label without running into errors. Otherwise the r2 dataframe is generated per view and group only, but no Factor column is included